### PR TITLE
Prepared TelegramConsumer Integration

### DIFF
--- a/Consumer.Tests/ConsumerIntegrationTests.cs
+++ b/Consumer.Tests/ConsumerIntegrationTests.cs
@@ -33,7 +33,7 @@ namespace Consumer.Tests
             Result<Message<Unit, Update>> messages = await GetConsumedMessages()
                 .FirstOrDefaultAsync();
 
-            Assert.AreEqual(UpdateContent, messages?.Value?.Value.Content);
+            Assert.AreEqual(UpdateContent, messages?.Value?.Value.Value.Content);
         }
 
         private static IObservable<Result<Message<Unit, Update>>> GetConsumedMessages()

--- a/Consumer/Consumer.cs
+++ b/Consumer/Consumer.cs
@@ -75,26 +75,26 @@ namespace Consumer
 
         private Result<Message<TKey, TValue>> SuccessMessageResult(RawKafkaRecord record)
         {
+            var key = record.Key;
+            var value = record.Value;
+           
             var message = new Message<TKey, TValue>
             {
-                Key = default,
-                Value = default,
+                Key = Deserialize<TKey>(key),
+                Value = Deserialize<TValue>(value),
                 Timestamp = record.Timestamp,
                 Topic = record.Topic
             };
-            if (record.Key != null)
-            {
-                message.Key = Deserialize<TKey>(record.Key);
-            }
-            if (record.Value != null)
-            {
-                message.Value = Deserialize<TValue>(record.Value);
-            }
-
+            
             return Result<Message<TKey, TValue>>.Success(message);
         }
 
-        private T Deserialize<T>(object bytes)
-            => JsonSerializer.Deserialize<T>(bytes as byte[], _options);
+        private Optional<T> Deserialize<T>(object bytes)
+        {
+            return bytes == null
+                ? Optional<T>.Empty()
+                : Optional<T>.WithValue(
+                    JsonSerializer.Deserialize<T>(bytes as byte[], _options));
+        }
     }
 }

--- a/Consumer/Consumer.csproj.DotSettings
+++ b/Consumer/Consumer.csproj.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=optional/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=result/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Consumer/Message.cs
+++ b/Consumer/Message.cs
@@ -4,14 +4,17 @@ namespace Consumer
 {
     public class Message<TKey, TValue>
     {
-        public TKey Key { get; set; }
+        public Optional<TKey> Key { get; set; }
 
-        public TValue Value { get; set; }
+        public Optional<TValue> Value { get; set; }
 
         public DateTime Timestamp { get; set; }
 
         public string Topic { get; set; }
 
-        public override string ToString() => $"Key = {Key}, Value = {Value}, Timestamp = {Timestamp:f}, Topic = {Topic}";
+        public override string ToString()
+        {
+            return $"Key = {Key}, Value = {Value}, Timestamp = {Timestamp:f}, Topic = {Topic}";
+        }
     }
 }

--- a/Consumer/Message.cs
+++ b/Consumer/Message.cs
@@ -14,7 +14,15 @@ namespace Consumer
 
         public override string ToString()
         {
-            return $"Key = {Key}, Value = {Value}, Timestamp = {Timestamp:f}, Topic = {Topic}";
+            string keyString = Key.HasValue 
+                ? $"Key = {Key}, " 
+                : string.Empty;
+            
+            string valueString = Value.HasValue 
+                ? $"Value = {Value}, " 
+                : string.Empty;
+
+            return $"{keyString}{valueString}Timestamp = {Timestamp:f}, Topic = {Topic}"; ;
         }
     }
 }

--- a/Consumer/Optional/Optional.cs
+++ b/Consumer/Optional/Optional.cs
@@ -17,5 +17,14 @@ namespace Consumer
 
         public static Optional<T> Empty()
             => new Optional<T>(false, default);
+
+        public override string ToString()
+        {
+            string optional = $"Optional<{typeof(T)}>";
+
+            return HasValue 
+                ? $"{optional}: {Value}" 
+                : $"Empty {optional}";
+        }
     }
 }

--- a/Consumer/Optional/Optional.cs
+++ b/Consumer/Optional/Optional.cs
@@ -1,0 +1,21 @@
+namespace Consumer
+{
+    public class Optional<T>
+    {
+        public bool HasValue { get; set; }
+
+        public T Value { get; set; }
+
+        private Optional(bool hasValue, T value)
+        {
+            HasValue = hasValue;
+            Value = value;
+        }
+
+        public static Optional<T> WithValue(T value)
+            => new Optional<T>(true, value);
+
+        public static Optional<T> Empty()
+            => new Optional<T>(false, default);
+    }
+}

--- a/Consumer/Optional/OptionalExtensions.cs
+++ b/Consumer/Optional/OptionalExtensions.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Consumer
+{
+    public static class OptionalExtensions
+    {
+        public static Task DoAsync<T>(
+            this Optional<T> optional,
+            Func<T, Task> asyncFunc)
+        {
+            return optional.HasValue
+                ? asyncFunc(optional.Value)
+                : Task.CompletedTask;
+        }
+    }
+}

--- a/Consumer/Result/ResultExtensions.cs
+++ b/Consumer/Result/ResultExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 namespace Consumer
 {
@@ -15,13 +16,22 @@ namespace Consumer
 
             try
             {
-                TTarget value = valueGetter(result.Value);
+                var value = valueGetter(result.Value);
                 return Result<TTarget>.Success(value);
             }
             catch (Exception e)
             {
                 return Result<TTarget>.Failure(e.Message);
             }
+        }
+
+        public static Task DoAsync<T>(
+            this Result<T> result,
+            Func<T, Task> asyncFunc)
+        {
+            return result.IsSuccess
+                ? asyncFunc(result.Value) 
+                : Task.CompletedTask;
         }
     }
 }

--- a/Iris.sln
+++ b/Iris.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Consumer.Tests", "Consumer.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TelegramConsumer", "TelegramConsumer\TelegramConsumer.csproj", "{F7CC73B4-E6A9-4CE4-9665-E7A5030B502F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TelegramConsumer.Tests", "TelegramConsumer.Tests\TelegramConsumer.Tests.csproj", "{6BC0582D-9162-4E4F-9CAF-DA7328AAD7AE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{F7CC73B4-E6A9-4CE4-9665-E7A5030B502F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F7CC73B4-E6A9-4CE4-9665-E7A5030B502F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F7CC73B4-E6A9-4CE4-9665-E7A5030B502F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6BC0582D-9162-4E4F-9CAF-DA7328AAD7AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6BC0582D-9162-4E4F-9CAF-DA7328AAD7AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6BC0582D-9162-4E4F-9CAF-DA7328AAD7AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6BC0582D-9162-4E4F-9CAF-DA7328AAD7AE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TelegramConsumer.Tests/TelegramConsumer.Tests.csproj
+++ b/TelegramConsumer.Tests/TelegramConsumer.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+        <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+        <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    </ItemGroup>
+
+</Project>

--- a/TelegramConsumer.Tests/TelegramSenderTests.cs
+++ b/TelegramConsumer.Tests/TelegramSenderTests.cs
@@ -1,0 +1,13 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TelegramConsumer.Tests
+{
+    [TestClass]
+    public class UnitTest1
+    {
+        [TestMethod]
+        public void TestMethod1()
+        {
+        }
+    }
+}

--- a/TelegramConsumer/ISender.cs
+++ b/TelegramConsumer/ISender.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace TelegramConsumer
+{
+    public interface ISender
+    {
+        Task SendAsync(Update update);
+    }
+}

--- a/TelegramConsumer/Properties/launchSettings.json
+++ b/TelegramConsumer/Properties/launchSettings.json
@@ -1,7 +1,10 @@
 {
   "profiles": {
     "TelegramConsumer": {
-      "workingDirectory": "./././",
+      "workingDirectory": "../../../",
+      "environmentVariables": {
+        "ENVIRONMENT": "Development"
+      },
       "commandName": "Project"
     },
     "Docker": {

--- a/TelegramConsumer/Properties/launchSettings.json
+++ b/TelegramConsumer/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "profiles": {
     "TelegramConsumer": {
-      "workingDirectory": "../../../",
+      "workingDirectory": "./././",
       "commandName": "Project"
     },
     "Docker": {

--- a/TelegramConsumer/Startup.cs
+++ b/TelegramConsumer/Startup.cs
@@ -37,6 +37,8 @@ namespace TelegramConsumer
                         .AddCustomConsole()
                         .AddConfiguration(config))
                 .AddConsumer<Unit, Update>(updatesConsumerConfig)
+                .AddSingleton<ISender, TelegramSender>()
+                .AddHostedService<UpdateConsumer>()
                 .BuildServiceProvider();
         }
 

--- a/TelegramConsumer/TelegramConfig.cs
+++ b/TelegramConsumer/TelegramConfig.cs
@@ -1,7 +1,12 @@
-﻿namespace TelegramConsumer
+﻿using System.Collections.Generic;
+using Telegram.Bot.Types;
+
+namespace TelegramConsumer
 {
     public class TelegramConfig
     {
         public string AccessToken { get; set; }
+
+        public Dictionary<string, ChatId[]> UsernamesChatIds { get; set; }
     }
 }

--- a/TelegramConsumer/TelegramConfig.cs
+++ b/TelegramConsumer/TelegramConfig.cs
@@ -1,0 +1,7 @@
+﻿namespace TelegramConsumer
+{
+    public class TelegramConfig
+    {
+        public string AccessToken { get; set; }
+    }
+}

--- a/TelegramConsumer/TelegramConsumer.csproj
+++ b/TelegramConsumer/TelegramConsumer.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.5" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.5" />
       <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
       <PackageReference Include="System.Reactive" Version="4.4.1" />
     </ItemGroup>

--- a/TelegramConsumer/TelegramConsumer.csproj
+++ b/TelegramConsumer/TelegramConsumer.csproj
@@ -8,9 +8,10 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.5" />
-      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.5" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
       <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
       <PackageReference Include="System.Reactive" Version="4.4.1" />
+      <PackageReference Include="Telegram.Bot" Version="15.7.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TelegramConsumer/TelegramSender.cs
+++ b/TelegramConsumer/TelegramSender.cs
@@ -1,14 +1,10 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Telegram.Bot;
+using Telegram.Bot.Types;
 
 namespace TelegramConsumer
 {
-    public class TelegramConfig
-    {
-        public string AccessToken { get; set; }
-    }
-
     public class TelegramSender : ISender
     {
         private readonly TelegramBotClient _client;
@@ -21,7 +17,7 @@ namespace TelegramConsumer
             _client = new TelegramBotClient(config.AccessToken);
             _logger = logger;
 
-            var identity = _client.GetMeAsync().Result;
+            User identity = _client.GetMeAsync().Result;
 
             _logger.LogInformation(
                 "Registered as {} {} (Username = {}, Id = {})",

--- a/TelegramConsumer/TelegramSender.cs
+++ b/TelegramConsumer/TelegramSender.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace TelegramConsumer
+{
+    public class TelegramSender : ISender
+    {
+        private readonly ILogger<TelegramSender> _logger;
+
+        public TelegramSender(ILogger<TelegramSender> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task SendAsync(Update update)
+        {
+            _logger.LogInformation("Sending update {}", update);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/TelegramConsumer/TelegramSender.cs
+++ b/TelegramConsumer/TelegramSender.cs
@@ -1,15 +1,34 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Telegram.Bot;
 
 namespace TelegramConsumer
 {
+    public class TelegramConfig
+    {
+        public string AccessToken { get; set; }
+    }
+
     public class TelegramSender : ISender
     {
+        private readonly TelegramBotClient _client;
         private readonly ILogger<TelegramSender> _logger;
 
-        public TelegramSender(ILogger<TelegramSender> logger)
+        public TelegramSender(
+            TelegramConfig config,
+            ILogger<TelegramSender> logger)
         {
+            _client = new TelegramBotClient(config.AccessToken);
             _logger = logger;
+
+            var identity = _client.GetMeAsync().Result;
+
+            _logger.LogInformation(
+                "Registered as {} {} (Username = {}, Id = {})",
+                identity.FirstName,
+                identity.LastName,
+                identity.Username,
+                identity.Id);
         }
 
         public Task SendAsync(Update update)

--- a/TelegramConsumer/TelegramSender.cs
+++ b/TelegramConsumer/TelegramSender.cs
@@ -7,6 +7,7 @@ namespace TelegramConsumer
 {
     public class TelegramSender : ISender
     {
+        private readonly TelegramConfig _config;
         private readonly TelegramBotClient _client;
         private readonly ILogger<TelegramSender> _logger;
 
@@ -14,6 +15,7 @@ namespace TelegramConsumer
             TelegramConfig config,
             ILogger<TelegramSender> logger)
         {
+            _config = config;
             _client = new TelegramBotClient(config.AccessToken);
             _logger = logger;
 
@@ -30,7 +32,7 @@ namespace TelegramConsumer
         public Task SendAsync(Update update)
         {
             _logger.LogInformation("Sending update {}", update);
-
+            
             return Task.CompletedTask;
         }
     }

--- a/TelegramConsumer/Update.cs
+++ b/TelegramConsumer/Update.cs
@@ -13,5 +13,10 @@ namespace TelegramConsumer
 
         [JsonPropertyName("url")]
         public string Url { get; set; }
+
+        public override string ToString()
+        {
+            return $"CreationDate = {CreationDate:f}, Url = ${Url}";
+        }
     }
 }

--- a/TelegramConsumer/UpdateConsumer.cs
+++ b/TelegramConsumer/UpdateConsumer.cs
@@ -4,20 +4,53 @@ using System.Threading;
 using System.Threading.Tasks;
 using Consumer;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace TelegramConsumer
 {
     public class UpdateConsumer : IHostedService
     {
         private readonly Consumer<Unit, Update> _updateConsumer;
+        private readonly ISender _sender;
+        private readonly ILogger<UpdateConsumer> _logger;
+        private IDisposable _updateSubscription;
 
-        public UpdateConsumer(Consumer<Unit, Update> updateConsumer)
+        public UpdateConsumer(
+            Consumer<Unit, Update> updateConsumer, 
+            ISender sender,
+            ILogger<UpdateConsumer> logger)
         {
             _updateConsumer = updateConsumer;
+            _sender = sender;
+            _logger = logger;
         }
 
-        public Task StartAsync(CancellationToken cancellationToken) => throw new System.NotImplementedException();
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _updateSubscription = _updateConsumer.Messages.Subscribe(
+                OnNext,
+                exception => _logger.LogError(exception, "Received error"),
+                () => _logger.LogInformation("Update stream is completed"));
 
-        public Task StopAsync(CancellationToken cancellationToken) => throw new System.NotImplementedException();
+            // If starting process is cancelled, dispose the update subscription
+            cancellationToken.Register(() => _updateSubscription?.Dispose());
+
+            return Task.CompletedTask;
+        }
+
+        private void OnNext(Result<Message<Unit, Update>> result)
+        {
+            _logger.LogInformation("Received result of update {}", result);
+
+            result.DoAsync(
+                message => message.Value.DoAsync(_sender.SendAsync));
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _updateSubscription?.Dispose();
+
+            return Task.CompletedTask;
+        }
     }
 }

--- a/TelegramConsumer/UpdateConsumer.cs
+++ b/TelegramConsumer/UpdateConsumer.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Reactive;
+using System.Threading;
+using System.Threading.Tasks;
+using Consumer;
+using Microsoft.Extensions.Hosting;
+
+namespace TelegramConsumer
+{
+    public class UpdateConsumer : IHostedService
+    {
+        private readonly Consumer<Unit, Update> _updateConsumer;
+
+        public UpdateConsumer(Consumer<Unit, Update> updateConsumer)
+        {
+            _updateConsumer = updateConsumer;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken) => throw new System.NotImplementedException();
+
+        public Task StopAsync(CancellationToken cancellationToken) => throw new System.NotImplementedException();
+    }
+}

--- a/TelegramConsumer/appsettings.Development.json
+++ b/TelegramConsumer/appsettings.Development.json
@@ -1,16 +1,19 @@
 {
-    "Logging": {
-        "LogLevel": {
-            "Default": "Debug",
-            "System": "Information",
-            "Microsoft": "Information"
-        }
-    },
-    "UpdatesConsumer": {
-        "Topics": [
-            "updates"   
-        ],
-        "GroupId": "test-consumer-group",
-        "BrokersServers": "localhost:9092"
-    }
+  "Logging": {
+      "LogLevel": {
+          "Default": "Debug",
+          "System": "Information",
+          "Microsoft": "Information"
+      }
+  },
+  "UpdatesConsumer": {
+      "Topics": [
+          "updates"
+      ],
+      "GroupId": "test-consumer-group",
+      "BrokersServers": "localhost:9092"
+  },
+  "Telegram": {
+    "AccessToken": "1073759913:AAEHDxkcx3zOO7PFvWwgi7yIJn8IIYhc9pA"
+  }
 }

--- a/TelegramConsumer/appsettings.Development.json
+++ b/TelegramConsumer/appsettings.Development.json
@@ -10,7 +10,6 @@
         "Topics": [
             "updates"   
         ],
-        "PollIntervalSeconds": 0.1,
         "GroupId": "test-consumer-group",
         "BrokersServers": "localhost:9092"
     }

--- a/TelegramConsumer/appsettings.json
+++ b/TelegramConsumer/appsettings.json
@@ -10,7 +10,6 @@
         "Topics": [
             "updates"
         ],
-        "PollIntervalSeconds": 5,
         "GroupId": "test-consumer-group",
         "BrokersServers": "localhost:9092"
     }


### PR DESCRIPTION
This PR includes the following changes:

- [x] Converted Consumer to a .NET Standard 2.0 class library (along with Extensions)
- [x] Added a hosted app called TelegramConsumer (which right now simply logs the consumed Kafka Updates from the `updates` topic)
- [x] Added the use of `Optional<TKey>` and `Optional<TValue>` for `Message`
- [x] Improved the `.ToString();` overrides implementations of each data class
- [x] Added an empty Unit tests project for TelegramConsumer
- [x] Added a simple `Telegram.Bot` client in `TelegramSender`